### PR TITLE
Fix ci lint reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 concurrency:
   group: ci-${{ github.head_ref }}
   cancel-in-progress: true
@@ -23,25 +25,54 @@ jobs:
         run: npx expo install --check
       - name: Run Expo Doctor
         run: npx expo-doctor
-      #      - name: Get Changed Files
-      #        run: |
-      #          cat $GITHUB_EVENT_PATH
-      #          BASE=$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")
-      #          HEAD=$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")
-      #
-      #          git diff --name-only "$BASE" "$HEAD" > changed.txt
-      #
-      #          echo "Changed files:"
-      #          cat changed.txt
       - name: Run Prettier
         run: npm run format:check
+      - name: Get Files Changed (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require("node:fs/promises");
+            const nodePath = require("node:path");
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+
+            const paths = files.map(file => file.filename);
+
+            const outPath = nodePath.join(process.env.GITHUB_WORKSPACE, "files-changed.json");
+            fs.writeFile(outPath, JSON.stringify(paths, null, 2));
+
+            core.exportVariable("FILES_CHANGED_JSON", outPath);
+      - name: Get Files Changed (Merge Group)
+        if: ${{ github.event_name == 'merge_group' }}
+        run: |
+          base_ref="${{ github.event.merge_group.base_ref }}"
+          base_sha="${{ github.event.merge_group.base_sha }}"
+          head_sha="${{ github.sha }}"
+
+          echo "Base ref: $base_ref"
+          echo "Base SHA: $base_sha"
+          echo "Head SHA: $head_sha"
+
+          git fetch --no-tags --prune --depth=200 origin "$base_ref"
+
+          git diff --name-only --diff-filter=ACMRT "$base_sha" "$head_sha" |
+            jq -Rsc 'split("\n")[:-1]' >files-changed.json
+
+          echo "FILES_CHANGED_JSON=$PWD/files-changed.json" >>"$GITHUB_ENV"
       - name: Run ESLint
         run: npm run lint -- -f json -o eslint-report.json || true
       - name: Run tsc
         run: node ./scripts/ci-tsc-report.mjs > tsc-report.json || true
-      #      - name: Report
-      #        run: node ./scripts/ci-filter-reports.mjs changed.txt eslint-report.json tsc-report.json
+      - name: Report
+        run: |
+          node ./scripts/ci-filter-reports.mjs "$FILES_CHANGED_JSON" eslint-report.json tsc-report.json
       - name: Run Tests
+        # TODO: enable
         if: false
         run: npx jest --ci --coverage
 #  build:

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,6 @@ yarn-error.*
 ### Added by the devlopers
 /coverage/
 android/
-changed.txt
+files-changed.json
 eslint-report.json
 tsc-report.json

--- a/scripts/ci-tsc-report.mjs
+++ b/scripts/ci-tsc-report.mjs
@@ -7,12 +7,13 @@ const configPath = ts.findConfigFile(cwd, ts.sys.fileExists, "tsconfig.json");
 
 if (!configPath) {
   console.error("No tsconfig.json found");
+
   process.exit(0);
 }
 
-const cfg = ts.readConfigFile(configPath, ts.sys.readFile).config;
+const config = ts.readConfigFile(configPath, ts.sys.readFile).config;
 const parsed = ts.parseJsonConfigFileContent(
-  cfg,
+  config,
   ts.sys,
   path.dirname(configPath),
 );
@@ -20,21 +21,23 @@ const parsed = ts.parseJsonConfigFileContent(
 const program = ts.createProgram(parsed.fileNames, parsed.options);
 const diagnostics = ts.getPreEmitDiagnostics(program);
 
-const out = diagnostics.map((d) => {
-  const f = d.file?.fileName ? path.relative(cwd, d.file.fileName) : null;
+const out = diagnostics.map((diagnostic) => {
+  const file = diagnostic.file?.fileName
+    ? path.relative(cwd, diagnostic.file.fileName)
+    : null;
 
   const { line = 0, character = 0 } =
-    d.file && d.start != null
-      ? d.file.getLineAndCharacterOfPosition(d.start)
+    diagnostic.file && diagnostic.start != null
+      ? diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start)
       : {};
 
   return {
-    file: f,
+    file: file,
     line: line + 1,
     column: character + 1,
-    code: d.code,
-    category: ts.DiagnosticCategory[d.category],
-    message: ts.flattenDiagnosticMessageText(d.messageText, "\n"),
+    code: diagnostic.code,
+    category: ts.DiagnosticCategory[diagnostic.category],
+    message: ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
   };
 });
 


### PR DESCRIPTION
This commit adds a step to the CI workflow that fails if there are ESLint or tsc issues in _changed_ files. E.g. if the developer has worked on `services/storage-service.ts`, but hasn't addressed the ESLint or tsc problems in that file, the workflow will fail.

<img width="1109" height="1293" alt="image" src="https://github.com/user-attachments/assets/8134aadf-8902-4e76-8c97-26906861788d" />

All other problems in the codebase pass.