### PR TITLE
Fix #480. Add scripts for local GitHub CI workflow execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ tsc-report.json
 .direnv/
 .envrc
 summary.md
+var/

--- a/.idea/educado-mobile.iml
+++ b/.idea/educado-mobile.iml
@@ -8,6 +8,8 @@
       <excludeFolder url="file://$MODULE_DIR$/.expo" />
       <excludeFolder url="file://$MODULE_DIR$/coverage" />
       <excludeFolder url="file://$MODULE_DIR$/android" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/httpRequests" />
+      <excludeFolder url="file://$MODULE_DIR$/var" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,7 +24,7 @@ const disallowedColors = Object.keys(colorTokens["old-colors"]);
 // The config works as it should, but due to some issues with `eslint-plugin-prefer-arrow-functions`, a couple of errors
 // are suppressed
 export default defineConfig([
-  globalIgnores([".expo/*", "**/dist/*", "scripts/*", "*.config.js"]),
+  globalIgnores([".expo/*", "**/dist/*", "*.config.js"]),
   expoConfig,
   eslint.configs.recommended,
   // I double-checked that this is the correct way to import the config

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:config": "npm -w @educado/eslint-config-educado run build",
     "build:packages": "npm run build:plugin && npm run build:config",
     "build:plugin": "npm -w @educado/eslint-plugin-educado run build",
+    "ci:local": "ts-node ./scripts/ci-local.ts",
     "ci:report": "node ./scripts/ci-report-problems.mjs",
     "format": "prettier -w .",
     "format:check": "prettier -c .",

--- a/scripts/ci-local.ts
+++ b/scripts/ci-local.ts
@@ -1,0 +1,171 @@
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const logDirectory = path.join(root, "var/log");
+
+const filesChangedJson = path.join(root, "files-changed.json");
+const eslintReportJson = path.join(root, "eslint-report.json");
+const tscReportJson = path.join(root, "tsc-report.json");
+
+const slug = (string: string) =>
+  string
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+
+const run = async (stepName: string, command: string) => {
+  const logFilePath = path.join(logDirectory, `${slug(stepName)}.log`);
+
+  const child = spawn(command, {
+    shell: true,
+    cwd: root,
+    env: process.env,
+  });
+
+  let stdout = "";
+  let stderr = "";
+
+  child.stdout.on("data", (chunk: string) => (stdout += chunk));
+  child.stderr.on("data", (chunk: string) => (stderr += chunk));
+
+  const exitCode: number = await new Promise((resolve) => {
+    child.on("close", resolve);
+  });
+
+  await fs.writeFile(logFilePath, stdout + stderr, "utf8");
+
+  return { exitCode, stdout, stderr, logFilePath };
+};
+
+const detectChangedFiles = async (stepName: string) => {
+  const diffFilter = "ACMRT";
+
+  await run(stepName, "git fetch --no-tags --prune");
+
+  const { stdout: base } = await run(
+    stepName,
+    "git merge-base HEAD origin/dev",
+  );
+
+  const { stdout: committed } = await run(
+    stepName,
+    `git diff --name-only --diff-filter=${diffFilter} ${base.trim()} HEAD`,
+  );
+
+  const { stdout: staged } = await run(
+    stepName,
+    `git diff --staged --name-only --diff-filter=${diffFilter}`,
+  );
+
+  // const modified = await run(`diff --name-only --diff-filter=${diffFilter}`);
+
+  const files = new Set<string>();
+
+  [committed, staged]
+    .flatMap((string) => (string ? string.split(/\r?\n/) : []))
+    .filter(Boolean)
+    .forEach((file) => files.add(file));
+
+  const filesChanged = Array.from(files.values()).sort();
+
+  await fs.writeFile(
+    filesChangedJson,
+    JSON.stringify(filesChanged, null, 2),
+    "utf8",
+  );
+
+  console.log(
+    `\n\x1b[34mFiles changed (${String(filesChanged.length)}):\x1b[0m`,
+  );
+
+  filesChanged.forEach((file) => {
+    console.log(`    ${file}`);
+  });
+};
+
+const ensureLogDir = async () => {
+  await fs.mkdir(logDirectory, { recursive: true });
+};
+
+const clearSummaryMd = async () => {
+  await fs.writeFile(path.join(root, "summary.md"), "", "utf8");
+};
+
+const steps = [
+  // { name: "Install Dependencies", cmd: "npm ci" },
+  { name: "Check Dependencies", command: "npx expo install --check" },
+  { name: "Run Expo Doctor", command: "npx expo-doctor" },
+  { name: "Run Prettier", command: "npm run format:check" },
+  { name: "Get Files Changed", function: detectChangedFiles },
+  {
+    name: "Run ESLint",
+    command: "npm run lint:ci",
+    continueOnError: true,
+  },
+  {
+    name: "Run tsc",
+    command: "npm run tsc:ci",
+    continueOnError: true,
+  },
+  {
+    name: "Report",
+    command: `npm run ci:report "${filesChangedJson}" "${eslintReportJson}" "${tscReportJson}"`,
+    continueOnError: true,
+  },
+  { name: "Run Tests", command: "npm run test:ci" },
+];
+
+(async () => {
+  await ensureLogDir();
+  await clearSummaryMd();
+
+  let overallExitCode = 0;
+
+  for (const step of steps) {
+    const start = Date.now();
+
+    process.stdout.write(`\x1b[33m${step.name} ...\x1b[0m `);
+
+    if (step.function) {
+      await step.function(step.name);
+
+      const duration = ((Date.now() - start) / 1000).toFixed(1);
+
+      console.log(`\x1b[32mdone (${duration}s)\x1b[0m`);
+
+      continue;
+    }
+
+    const { exitCode } = await run(step.name, step.command);
+
+    const duration = ((Date.now() - start) / 1000).toFixed(1);
+
+    if (exitCode !== 0) {
+      console.error(`\x1b[31mfailed (${duration}s)\x1b[0m`);
+
+      if (step.continueOnError) {
+        overallExitCode = overallExitCode || exitCode;
+
+        continue;
+      }
+
+      process.exit(exitCode);
+    }
+
+    console.log(`\x1b[32mdone (${duration}s)\x1b[0m`);
+  }
+
+  if (overallExitCode !== 0) {
+    console.error(
+      "\n\x1b[31mSome steps reported non-zero exit codes (continued on error). See `var/log/`, `summary.md` and JSON reports for details.\x1b[0m",
+    );
+  }
+
+  process.exit(overallExitCode);
+})().catch((error: unknown) => {
+  console.error(error);
+
+  process.exit(1);
+});


### PR DESCRIPTION
# Pull Request

## Description

Now running `npm run ci:local` runs (almost) the same steps as the GitHub CI workflow to check the code before opening a PR.

## Checklist

- [x] The functionality meets the related user story or issue
- [ ] I have followed and applied the Figma design (if applicable)
- [x] I have added at least two reviewers, with one of them being from another team
- [x] I have written or updated tests related to this change
- [ ] I have updated the documentation related to this change (if applicable)
- [x] I have followed the [coding standards of this project](https://erasmusegalitarian.github.io/educado-docs/handbook/mobile/standards/)
- [x] I have followed the [workflow of this project](https://erasmusegalitarian.github.io/educado-docs/handbook/mobile/workflow/)
- [x] I have built the code locally and tested that it works
  - [x] My changes are not breaking existing functionality
- I am keeping track of other PRs and ensuring that:
  - [x] they are not blocking this PR
  - [x] they are not blocked by this PR
  - [x] this branch is kept updated by running `git fetch && git rebase origin/dev` whenever another PR is merged
- [x] I will add the PR to the merge queue after it is approved

## Screenshot

<img width="286" height="362" alt="image" src="https://github.com/user-attachments/assets/1ec13eaa-bc65-46d9-9c7c-12d14b42c704" />
