### PR TITLE
Update .prettierignore to exclude CHANGELOG.md

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 build
 coverage
 .idea
+CHANGELOG.md


### PR DESCRIPTION
# Pull Request

## Description

Currently Prettier tries to check if `CHANGELOG.md` is formatted correctly. This is causing issues for CI checks running on the temporary release please branch. It should just be ignored since the format of the changelog is auto generated and handled by the workflow.


## Checklist

- [x] The functionality meets the related user story or issue
- [ ] I have followed and applied the Figma design (if applicable)
- [ ] I have added at least two reviewers, with one of them being from another team
- [ ] I have written or updated tests related to this change
- [ ] I have updated the documentation related to this change (if applicable)
- [x] I have followed the [coding standards of this project](https://erasmusegalitarian.github.io/educado-docs/handbook/mobile/standards/)
- [x] I have followed the [workflow of this project](https://erasmusegalitarian.github.io/educado-docs/handbook/mobile/workflow/)
- [ ] I have built the code locally and tested that it works
  - [ ] My changes are not breaking existing functionality
- I am keeping track of other PRs and ensuring that:
  - [ ] they are not blocking this PR
  - [ ] they are not blocked by this PR
  - [x] this branch is kept updated by running `git fetch && git rebase origin/dev` whenever another PR is merged
- [x] I will add the PR to the merge queue after it is approved
